### PR TITLE
ci: disable schedule

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,10 +6,6 @@ on:
       - .github/workflows/validate.yml
       - '*.json5'
 
-  # every 5:00 AM Saturday (JST)
-  schedule:
-    - cron: '0 20 * * 5'
-
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

- GitHub Actions workflow has disabled so this repository was inactive for 60 days
- but this workflow to be active for push event

## What

- disable schedule execution