### PR TITLE
automerge github-actions packages only patch versions

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -24,6 +24,7 @@
   packageRules: [
     {
       matchManagers: ['github-actions'],
+      matchUpdateTypes: ['patch'],
       automerge: true,
     },
   ],


### PR DESCRIPTION
#4

major or minor versions often have breaking changes, so they should not be merged automatically