### PR TITLE
feat: group mise bun with @types/bun

### DIFF
--- a/node.json5
+++ b/node.json5
@@ -14,5 +14,15 @@
       matchUpdateTypes: ['patch', 'pin', 'digest'],
       automerge: true,
     },
+    {
+      matchManagers: ['mise'],
+      matchPackageNames: ['bun'],
+      groupName: 'bun',
+    },
+    {
+      matchManagers: ['npm', 'bun'],
+      matchPackageNames: ['@types/bun'],
+      groupName: 'bun',
+    },
   ],
 }


### PR DESCRIPTION
## Why

- When using `mise` to manage the Bun runtime version and `@types/bun` for TypeScript types, these dependencies should be updated together to ensure version compatibility
- Without grouping, users might get separate PRs that could lead to version mismatches between the runtime and its type definitions

## What

- Bun runtime updates from `mise` and `@types/bun` package updates will be grouped into a single PR
- This ensures synchronized updates and reduces PR noise for Bun-related dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)