### PR TITLE
feat: enable automerge for @cloudflare/workers-types

### DIFF
--- a/node.json5
+++ b/node.json5
@@ -24,5 +24,12 @@
       matchPackageNames: ['@types/bun'],
       groupName: 'bun',
     },
+    {
+      // @cloudflare/workers-types uses date-based versioning (<major>.<YYYYMMDD>.<patch>),
+      // but we can safely automerge since CI type checking ensures compatibility
+      matchPackageNames: ['@cloudflare/workers-types'],
+      matchUpdateTypes: ['minor', 'patch'],
+      automerge: true,
+    },
   ],
 }


### PR DESCRIPTION
## Why

- `@cloudflare/workers-types` uses date-based versioning (`<major>.<YYYYMMDD>.<patch>`) instead of semantic versioning
- Currently requires manual review for every update despite being a devDependency
- Type checking in CI already ensures compatibility
- Want to enable automerge for PRs like https://github.com/fohte/tasker/pull/29

## What

- Automerge will be enabled for `@cloudflare/workers-types` minor and patch updates
- Reduces manual PR review overhead while maintaining safety through CI checks

🤖 Generated with [Claude Code](https://claude.ai/code)