### PR TITLE
feat: set rangeStrategy to auto for peerDependencies

### DIFF
--- a/node.json5
+++ b/node.json5
@@ -33,5 +33,12 @@
       matchUpdateTypes: ['minor', 'patch'],
       automerge: true,
     },
+    {
+      // Keep peerDependencies range specifications (e.g., ^6.0.0 || ^7.0.0)
+      // to maintain flexibility for consuming projects
+      matchManagers: ['npm', 'bun'],
+      matchDepTypes: ['peerDependencies'],
+      rangeStrategy: 'auto',
+    },
   ],
 }


### PR DESCRIPTION
## Why

- Renovate is pinning peerDependencies to exact versions (e.g., `^6.0.0 || ^7.0.0` → `7.18.0`) in ESLint config packages
- peerDependencies should maintain range specifications to provide flexibility for consuming projects
- This issue was observed in https://github.com/fohte/eslint-config/pull/59

## What

- Add a packageRule that sets `rangeStrategy: auto` for peerDependencies
- This preserves existing range specifications while still allowing updates
- Helps avoid dependency conflicts in projects using these packages

🤖 Generated with [Claude Code](https://claude.ai/code)