### PR TITLE
node: group major/minor updates for Node and @types/node

### DIFF
--- a/lefthook.json5
+++ b/lefthook.json5
@@ -7,7 +7,7 @@
       // Note: lefthook remotes only support branch/tag names, not commit hashes
       // Usage: ref: v0.1.3 # renovate: datasource=github-tags depName=fohte/lefthook-config
       customType: 'regex',
-      fileMatch: ['(^|/)lefthook\\.ya?ml(\\.jinja)?$'],
+      managerFilePatterns: ['/(^|/)lefthook\\.ya?ml(\\.jinja)?$/'],
       matchStrings: [
         'ref:\\s*(?<currentValue>v?\\d[^\\s#]*)\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)',
       ],

--- a/node.json5
+++ b/node.json5
@@ -71,6 +71,23 @@
       matchPackageNames: ['@types/bun', 'bun-types'],
       groupName: 'bun',
     },
+    // Group Node.js runtime and @types/node together for major/minor updates.
+    // DefinitelyTyped aligns @types/node's major/minor with Node, but patch is
+    // an independent DefinitelyTyped revision counter unrelated to Node patches,
+    // so grouping patches would block one side waiting on the other.
+    // https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library
+    {
+      matchManagers: ['mise'],
+      matchPackageNames: ['node'],
+      matchUpdateTypes: ['major', 'minor'],
+      groupName: 'node',
+    },
+    {
+      matchManagers: ['npm', 'bun'],
+      matchPackageNames: ['@types/node'],
+      matchUpdateTypes: ['major', 'minor'],
+      groupName: 'node',
+    },
 
     // ==========================================================================
     // rangeStrategy

--- a/node.json5
+++ b/node.json5
@@ -71,10 +71,8 @@
       matchPackageNames: ['@types/bun', 'bun-types'],
       groupName: 'bun',
     },
-    // Group Node.js runtime and @types/node together for major/minor updates.
-    // DefinitelyTyped aligns @types/node's major/minor with Node, but patch is
-    // an independent DefinitelyTyped revision counter unrelated to Node patches,
-    // so grouping patches would block one side waiting on the other.
+    // Group Node.js and @types/node major/minor updates; patches are excluded as
+    // DefinitelyTyped patch versions are independent revision counters.
     // https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library
     {
       matchManagers: ['mise'],


### PR DESCRIPTION
## Purpose

- Node.js (managed by mise) and `@types/node` (npm) are updated in separate PRs, which can lead to version mismatches between them

## Approach

- Group Node and `@types/node` major/minor updates into a single PR
- Exclude patch updates from the group so neither side blocks waiting on the other
    - `@types/node` patches are an independent DefinitelyTyped revision counter and do not track Node patches
    - > How do Definitely Typed package versions relate to versions of the corresponding library?
      > [...] The patch release number of the type declaration package is unrelated to the library patch version number.
      > [DefinitelyTyped README](https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library)
