### PR TITLE
base: automerge `@types/*` patch updates

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -85,7 +85,8 @@
       matchUpdateTypes: ['patch', 'digest'],
       automerge: true,
     },
-    // `@types/*` patch updates carry no runtime risk; type-level breakage is caught by downstream `tsc` in CI.
+    // DefinitelyTyped pins `@types/*` major.minor to the upstream library's major.minor, so a patch bump
+    // only ships type-definition fixes; any resulting type-level breakage is caught by downstream `tsc` in CI.
     {
       matchPackageNames: ['@types/**'],
       matchUpdateTypes: ['patch'],

--- a/base.json5
+++ b/base.json5
@@ -85,11 +85,7 @@
       matchUpdateTypes: ['patch', 'digest'],
       automerge: true,
     },
-    // DefinitelyTyped guarantees `@types/*` patch bumps only update type
-    // definitions for the same major.minor of the upstream library, so they
-    // carry no runtime risk. The only failure mode is stricter types breaking
-    // compilation, which downstream `tsc` in CI will catch before automerge.
-    // See https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library
+    // `@types/*` patch updates carry no runtime risk; type-level breakage is caught by downstream `tsc` in CI.
     {
       matchPackageNames: ['@types/**'],
       matchUpdateTypes: ['patch'],

--- a/base.json5
+++ b/base.json5
@@ -88,7 +88,7 @@
     // DefinitelyTyped pins `@types/*` major.minor to the upstream library's major.minor, so a patch bump
     // only ships type-definition fixes; any resulting type-level breakage is caught by downstream `tsc` in CI.
     {
-      matchPackageNames: ['@types/**'],
+      matchPackageNames: ['@types/*'],
       matchUpdateTypes: ['patch'],
       automerge: true,
     },

--- a/base.json5
+++ b/base.json5
@@ -85,6 +85,16 @@
       matchUpdateTypes: ['patch', 'digest'],
       automerge: true,
     },
+    // DefinitelyTyped guarantees `@types/*` patch bumps only update type
+    // definitions for the same major.minor of the upstream library, so they
+    // carry no runtime risk. The only failure mode is stricter types breaking
+    // compilation, which downstream `tsc` in CI will catch before automerge.
+    // See https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library
+    {
+      matchPackageNames: ['@types/**'],
+      matchUpdateTypes: ['patch'],
+      automerge: true,
+    },
 
     // ==========================================================================
     // labels


### PR DESCRIPTION
## Purpose

- Automerge `@types/*` patch updates to cut PR triage overhead, since CI can verify their safety
    - Per DefinitelyTyped's policy, `@types/*` patch bumps have no runtime impact, and the only residual risk — stricter types breaking compilation — is caught by `tsc` running in downstream repositories' CI
        > The patch release number of the type declaration package (e.g. `.0` in `20.8.0`) is initialized to zero by Definitely Typed and is incremented each time a new `@types/node` package is published to npm for the same major/minor version of the corresponding library.
        > [DefinitelyTyped README](https://github.com/DefinitelyTyped/DefinitelyTyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library)

## Approach

- Add a packageRule that automerges `@types/**` patch updates
