### PR TITLE
base: remove redundant `@types/*` patch automerge rule

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -85,13 +85,6 @@
       matchUpdateTypes: ['patch', 'digest'],
       automerge: true,
     },
-    // DefinitelyTyped pins `@types/*` major.minor to the upstream library's major.minor, so a patch bump
-    // only ships type-definition fixes; any resulting type-level breakage is caught by downstream `tsc` in CI.
-    {
-      matchPackageNames: ['@types/*'],
-      matchUpdateTypes: ['patch'],
-      automerge: true,
-    },
 
     // ==========================================================================
     // labels


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/renovate-config/pull/354
- The language-agnostic `base.json5` contains an npm-specific `@types/*` rule, so repositories that only extend `base.json5` (e.g. Go-only projects) end up evaluating an unrelated npm package rule

## Approach

- Remove the `@types/*`-specific rule from `base.json5`
    - The existing `matchManagers: ['npm', 'bun'], matchUpdateTypes: ['patch', 'pin', 'digest']` automerge in `node.json5` already covers `@types/*` patches, so drop the rule entirely
