### PR TITLE
base: enable branchNameStrict to strip special characters from branch names

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -20,12 +20,9 @@
   configMigration: true,
   timezone: 'Asia/Tokyo',
 
-  // Strip special characters (including parentheses) from branch names.
-  // octo-sts rejects OIDC token subjects containing any of `"'`\<>;&$(){}[]`
-  // (see IsValidSubject in octo-sts/app pkg/oidcvalidate/validate.go), so a
-  // branch like `renovate/devdependencies-(non-major)` produces the subject
-  // `repo:owner/repo:ref:refs/heads/renovate/devdependencies-(non-major)`,
-  // which fails token exchange with `invalid subject in token` and blocks the
+  // octo-sts rejects OIDC token subjects containing any of `"'`\<>;&$(){}[]`,
+  // so a branch like `renovate/devdependencies-(non-major)` produces a subject
+  // that fails token exchange with `invalid subject in token` and blocks the
   // PR's required status checks. The default branch-name cleanup keeps `()`;
   // strict mode replaces them with `-`, keeping subjects valid.
   branchNameStrict: true,

--- a/base.json5
+++ b/base.json5
@@ -23,8 +23,7 @@
   // octo-sts rejects OIDC token subjects containing any of `"'`\<>;&$(){}[]`,
   // so a branch like `renovate/devdependencies-(non-major)` produces a subject
   // that fails token exchange with `invalid subject in token` and blocks the
-  // PR's required status checks. The default branch-name cleanup keeps `()`;
-  // strict mode replaces them with `-`, keeping subjects valid.
+  // PR's required status checks.
   branchNameStrict: true,
 
   // Wait 7 days after a package release before creating a PR.

--- a/base.json5
+++ b/base.json5
@@ -20,6 +20,16 @@
   configMigration: true,
   timezone: 'Asia/Tokyo',
 
+  // Strip special characters (including parentheses) from branch names.
+  // octo-sts rejects OIDC token subjects containing any of `"'`\<>;&$(){}[]`
+  // (see IsValidSubject in octo-sts/app pkg/oidcvalidate/validate.go), so a
+  // branch like `renovate/devdependencies-(non-major)` produces the subject
+  // `repo:owner/repo:ref:refs/heads/renovate/devdependencies-(non-major)`,
+  // which fails token exchange with `invalid subject in token` and blocks the
+  // PR's required status checks. The default branch-name cleanup keeps `()`;
+  // strict mode replaces them with `-`, keeping subjects valid.
+  branchNameStrict: true,
+
   // Wait 7 days after a package release before creating a PR.
   // This helps mitigate supply chain attacks by allowing time for
   // security researchers and automated tools to detect malicious packages.


### PR DESCRIPTION
## Purpose

- Renovate PRs whose branch name contains parentheses `()` (e.g. `renovate/devdependencies-(non-major)`) always fail CI and become permanently unmergeable because their required check never passes
    - octo-sts rejects parentheses in the OIDC subject, so the token exchange at the start of the `test` workflow fails with `invalid subject in token`
    - This recurs in every repository that uses this preset

## Approach

- Enable `branchNameStrict: true` so branch names replace parentheses and other special characters with `-`, keeping the subject valid
    - `renovate/devdependencies-(non-major)` → `renovate/devdependencies-non-major`
