### PR TITLE
ci: switch sync-generic-boilerplate token retrieval to octo-sts

### DIFF
--- a/.github/workflows/sync-generic-boilerplate.yml
+++ b/.github/workflows/sync-generic-boilerplate.yml
@@ -7,18 +7,20 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  id-token: write
 
 jobs:
   sync:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        id: app-token
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          scope: fohte
+          identity: renovate-config-sync-generic-boilerplate
+          domain: octo-sts.fohte.net
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -51,4 +53,4 @@ jobs:
         with:
           commit_message: 'chore: sync generic-boilerplate package list'
           workflow: deny
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ steps.octo-sts.outputs.token }}


### PR DESCRIPTION
## Purpose

- Remove the dependency on the long-lived `APP_PRIVATE_KEY` secret by replacing it with short-lived tokens obtained via OIDC

## Approach

- Switch the [sync-generic-boilerplate workflow](https://github.com/fohte/renovate-config/blob/dd60fce/.github/workflows/sync-generic-boilerplate.yml) to obtain a GitHub App token through OIDC federation
    - The corresponding [OrgTrustPolicy](https://github.com/fohte/.github/blob/82a514e957e0c41fc665de1351bbc92915f21b7b/.github/chainguard/renovate-config-sync-generic-boilerplate.sts.yaml) is already in place
