### PR TITLE
rust: group clap monorepo crates into a single PR

### DIFF
--- a/rust.json5
+++ b/rust.json5
@@ -18,6 +18,17 @@
     },
 
     // ==========================================================================
+    // monorepo grouping
+    // ==========================================================================
+    // clap-rs/clap is not included in Renovate's built-in `group:monorepos`
+    // preset, so group it manually by sourceUrl.
+    {
+      matchManagers: ['cargo'],
+      matchSourceUrls: ['https://github.com/clap-rs/clap'],
+      groupName: 'clap monorepo',
+    },
+
+    // ==========================================================================
     // automerge
     // ==========================================================================
     {


### PR DESCRIPTION
## Purpose

- Merge clap, clap_complete, and other clap-rs/clap monorepo crates into a single PR since they are released together, removing the need to review and merge them separately

## Approach

- Group crates from clap-rs/clap with `matchSourceUrls`
