### PR TITLE
node: use chore: prefix for packageManager field updates

### DIFF
--- a/node.json5
+++ b/node.json5
@@ -91,7 +91,7 @@
     // release-please integration
     // ==========================================================================
     // The `packageManager` field is corepack-only and never reaches the published
-    // package, so override the default `deps:` prefix from base.json5.
+    // package, so updates should not trigger a release bump.
     {
       matchManagers: ['npm'],
       matchDepTypes: ['packageManager'],

--- a/node.json5
+++ b/node.json5
@@ -88,6 +88,18 @@
     },
 
     // ==========================================================================
+    // release-please integration
+    // ==========================================================================
+    // The `packageManager` field is corepack-only and never reaches the published
+    // package, so override the default `deps:` prefix from base.json5.
+    {
+      matchManagers: ['npm'],
+      matchDepTypes: ['packageManager'],
+      commitMessagePrefix: 'chore:',
+      semanticCommitScope: null,
+    },
+
+    // ==========================================================================
     // rangeStrategy
     // ==========================================================================
     {

--- a/tests/__fixtures__/pr-title-npm-package-manager/package.json
+++ b/tests/__fixtures__/pr-title-npm-package-manager/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-package-manager",
+  "version": "1.0.0",
+  "packageManager": "pnpm@1.0.0"
+}

--- a/tests/pr-title.test.ts
+++ b/tests/pr-title.test.ts
@@ -13,6 +13,7 @@ import {
 //   | github-actions  | ci:          | ci:          | ci:          | ci:          |
 //   | copier          | chore(deps): | chore(deps): | chore(deps): | chore(deps): |
 //   | mise            | chore:       | chore:       | chore:       | chore:       |
+//   | packageManager  | chore:       | chore:       | chore:       | chore:       |
 
 interface TestCase {
   category: string
@@ -84,6 +85,19 @@ const testCases: TestCase[] = [
       mockNpmPackages: [{ name: 'test-pkg-dev', versions: ['1.0.0', '1.1.0'] }],
     },
     depName: 'test-pkg-dev',
+    expectedPrefix: /^chore: /,
+    updateType: 'minor',
+  },
+  // packageManager (corepack)
+  {
+    category: 'packageManager',
+    description: 'minor update',
+    options: {
+      fixtures: ['pr-title-npm-package-manager/package.json'],
+      mockNpmPackages: [{ name: 'pnpm', versions: ['1.0.0', '1.1.0'] }],
+      additionalConfigs: ['node.json5'],
+    },
+    depName: 'pnpm',
     expectedPrefix: /^chore: /,
     updateType: 'minor',
   },


### PR DESCRIPTION
## Purpose

- Updates to `packageManager` (corepack) in `package.json` should not trigger a patch bump

## Approach

- Emit `chore:` commits for `packageManager` field updates
