### PR TITLE
base: stop treating dependency major bumps as breaking changes

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -129,9 +129,6 @@
     //   | github-actions  | ci:          | ci:          | ci:          | ci:          |
     //   | copier          | chore(deps): | chore(deps): | chore(deps): | chore(deps): |
     //   | mise            | chore:       | chore:       | chore:       | chore:       |
-    //
-    // Libraries whose public API exposes a dependency should override
-    // `deps:` with `deps!:` for major updates in their own renovate config.
     {
       matchUpdateTypes: ['major', 'minor', 'patch'],
       semanticCommitType: 'deps',

--- a/base.json5
+++ b/base.json5
@@ -124,17 +124,16 @@
     // Resulting semantic commit types:
     //   | Target          | major        | minor        | patch        | pin          |
     //   |-----------------|--------------|--------------|--------------|--------------|
-    //   | dependencies    | deps!:       | deps:        | deps:        | chore(deps): |
+    //   | dependencies    | deps:        | deps:        | deps:        | chore(deps): |
     //   | devDependencies | chore:       | chore:       | chore:       | chore:       |
     //   | github-actions  | ci:          | ci:          | ci:          | ci:          |
     //   | copier          | chore(deps): | chore(deps): | chore(deps): | chore(deps): |
     //   | mise            | chore:       | chore:       | chore:       | chore:       |
+    //
+    // Libraries whose public API exposes a dependency should override
+    // `deps:` with `deps!:` for major updates in their own renovate config.
     {
-      matchUpdateTypes: ['major'],
-      commitMessagePrefix: 'deps!:',
-    },
-    {
-      matchUpdateTypes: ['minor', 'patch'],
+      matchUpdateTypes: ['major', 'minor', 'patch'],
       semanticCommitType: 'deps',
       semanticCommitScope: null,
     },
@@ -146,8 +145,6 @@
     },
     {
       matchDepTypes: ['devDependencies'],
-      // Use commitMessagePrefix (not semanticCommitType) to override the
-      // 'deps!:' prefix set above for major updates.
       commitMessagePrefix: 'chore:',
       semanticCommitScope: null,
     },

--- a/tests/pr-title.test.ts
+++ b/tests/pr-title.test.ts
@@ -8,7 +8,7 @@ import {
 // Test PR title format according to release-please configuration in base.json5:
 //   | Target          | major        | minor        | patch        | pin          |
 //   |-----------------|--------------|--------------|--------------|--------------|
-//   | dependencies    | deps!:       | deps:        | deps:        | chore(deps): |
+//   | dependencies    | deps:        | deps:        | deps:        | chore(deps): |
 //   | devDependencies | chore:       | chore:       | chore:       | chore:       |
 //   | github-actions  | ci:          | ci:          | ci:          | ci:          |
 //   | copier          | chore(deps): | chore(deps): | chore(deps): | chore(deps): |
@@ -36,7 +36,7 @@ const testCases: TestCase[] = [
       ],
     },
     depName: 'test-pkg-major',
-    expectedPrefix: /^deps!: /,
+    expectedPrefix: /^deps: /,
     updateType: 'major',
   },
   {


### PR DESCRIPTION
## Purpose

- Stop the shared preset `base.json5` from mechanically prefixing dependency major bumps with `deps!:`
    - A dependency major bump is generally not a breaking change for the consuming repository
    - For example, runok's [shlex v1→v2 update](https://github.com/fohte/runok/pull/388) was only used in internal code, yet `deps!:` was attached and nearly triggered a major bump of runok itself

## Approach

- Use `deps:` for all of major / minor / patch and drop `deps!:` from the defaults
