### PR TITLE
base: track jdx/mise-action's `with: version:` via Renovate

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ Create a `renovate.json5` file in your repository with the following content:
 }
 ```
 
+`base.json5` includes a `customManager` that tracks `jdx/mise-action`'s
+`with: version:` as a `jdx/mise` release, so a workflow such as
+
+```yaml
+- uses: jdx/mise-action@v2
+  with:
+    version: 2026.6.6
+```
+
+is bumped automatically without any per-repository configuration.
+
 ### Node.js projects
 
 ```json5

--- a/base.json5
+++ b/base.json5
@@ -30,18 +30,14 @@
       // to that action.
       customType: 'regex',
       managerFilePatterns: ['/(^|/)\\.github/workflows/[^/]+\\.ya?ml$/'],
-      // The continuation pattern is `[ \t]+[^-\s]` (indent then a non-dash
-      // non-space first char). A naive `\s+[^\n]*` form bleeds past the
-      // `with:` block into a following step and would tag e.g.
-      // `pnpm/action-setup`'s `version:` as a `jdx/mise` release.
-      // Renovate's regex manager uses re2, which lacks back-references and
-      // look-around, so the cleaner "indent-pinned" form is not available.
-      // Known limitation: a YAML list value inside `with:` (lines starting
-      // with `-`) terminates the lazy run, which would cause a sibling
-      // `version:` after such a list to be missed. mise-action's inputs are
-      // all scalar so this does not arise in practice today.
+      // Anchored to a `uses:` line so a stray `jdx/mise-action@…` mention
+      // inside a `run:` script or comment cannot trigger extraction. The
+      // continuation pattern `[ \t]+[^-\s]` stops at the next step boundary;
+      // a YAML list value inside `with:` (line starting with `-`) also
+      // terminates the match, so a sibling `version:` placed after such a
+      // list would be missed.
       matchStrings: [
-        'jdx/mise-action@\\S+[^\\n]*\\n[ \\t]+with:[ \\t]*\\n(?:[ \\t]+[^-\\s][^\\n]*\\n)*?[ \\t]+version:\\s*(?<currentValue>\\S+)',
+        '[ \\t]+(?:- )?uses:[ \\t]+jdx/mise-action@\\S+[^\\n]*\\n[ \\t]+with:[ \\t]*\\n(?:[ \\t]+[^-\\s][^\\n]*\\n)*?[ \\t]+version:\\s*(?<currentValue>\\S+)',
       ],
       datasourceTemplate: 'github-releases',
       depNameTemplate: 'jdx/mise',

--- a/base.json5
+++ b/base.json5
@@ -20,6 +20,37 @@
   configMigration: true,
   timezone: 'Asia/Tokyo',
 
+  customManagers: [
+    {
+      // Track `jdx/mise-action`'s `with: version:` as a `jdx/mise` release.
+      // mise-action has no equivalent of `actions/setup-node`'s `.nvmrc`
+      // support, so a pinned mise version drifts silently without this
+      // manager. The regex is scoped to the `with:` block of a
+      // `jdx/mise-action@...` step so it only matches version keys belonging
+      // to that action.
+      customType: 'regex',
+      managerFilePatterns: ['/(^|/)\\.github/workflows/[^/]+\\.ya?ml$/'],
+      // The continuation pattern is `[ \t]+[^-\s]` (indent then a non-dash
+      // non-space first char). A naive `\s+[^\n]*` form bleeds past the
+      // `with:` block into a following step and would tag e.g.
+      // `pnpm/action-setup`'s `version:` as a `jdx/mise` release.
+      // Renovate's regex manager uses re2, which lacks back-references and
+      // look-around, so the cleaner "indent-pinned" form is not available.
+      // Known limitation: a YAML list value inside `with:` (lines starting
+      // with `-`) terminates the lazy run, which would cause a sibling
+      // `version:` after such a list to be missed. mise-action's inputs are
+      // all scalar so this does not arise in practice today.
+      matchStrings: [
+        'jdx/mise-action@\\S+[^\\n]*\\n[ \\t]+with:[ \\t]*\\n(?:[ \\t]+[^-\\s][^\\n]*\\n)*?[ \\t]+version:\\s*(?<currentValue>\\S+)',
+      ],
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'jdx/mise',
+      // mise tags are `vX.Y.Z` but `with: version:` is consumed without the
+      // leading `v`, so strip it from the looked-up version.
+      extractVersionTemplate: '^v(?<version>.+)$',
+    },
+  ],
+
   // octo-sts rejects OIDC token subjects containing any of `"'`\<>;&$(){}[]`,
   // so a branch like `renovate/devdependencies-(non-major)` produces a subject
   // that fails token exchange with `invalid subject in token` and blocks the

--- a/tests/helpers/renovate-test-context.ts
+++ b/tests/helpers/renovate-test-context.ts
@@ -67,6 +67,8 @@ export interface MockGitHubRepo {
 
 export interface SetupOptions {
   fixtures: string[]
+  // `{{MOCK_REPO:name}}` placeholders are substituted, matching fixtures behavior.
+  inlineFiles?: Record<string, string>
   mockRepos?: MockRepo[]
   mockCrates?: MockCrate[]
   mockNpmPackages?: MockNpmPackage[]
@@ -110,6 +112,7 @@ export class RenovateTestContext {
 
     const {
       fixtures,
+      inlineFiles = {},
       mockRepos = [],
       mockCrates = [],
       mockNpmPackages = [],
@@ -149,27 +152,31 @@ export class RenovateTestContext {
     // Initialize git repo (required for renovate --platform=local)
     initGitRepo(this.workDir)
 
+    const substituteMockRepos = (content: string): string =>
+      content.replace(/\{\{MOCK_REPO:([\w-]+)\}\}/g, (_, name: string) => {
+        const repoPath = this.mockRepoPaths.get(name)
+        if (repoPath === undefined) {
+          throw new Error(`Mock repo '${name}' not found`)
+        }
+        return `file://${repoPath}`
+      })
+
     // Copy test fixtures and replace placeholders
     for (const fixture of fixtures) {
       const srcPath = join(FIXTURES_DIR, fixture)
       const destPath = join(this.workDir, fixture)
-
-      // Create parent directories if needed
       mkdirSync(dirname(destPath), { recursive: true })
-
-      let content = readFileSync(srcPath, 'utf-8')
-      // Replace {{MOCK_REPO:name}} placeholders with file:// URLs
-      content = content.replace(
-        /\{\{MOCK_REPO:([\w-]+)\}\}/g,
-        (_, name: string) => {
-          const repoPath = this.mockRepoPaths.get(name)
-          if (repoPath === undefined) {
-            throw new Error(`Mock repo '${name}' not found`)
-          }
-          return `file://${repoPath}`
-        },
+      writeFileSync(
+        destPath,
+        substituteMockRepos(readFileSync(srcPath, 'utf-8')),
       )
-      writeFileSync(destPath, content)
+    }
+
+    // Write inline files (heredoc-style payloads) into workDir
+    for (const [relPath, content] of Object.entries(inlineFiles)) {
+      const destPath = join(this.workDir, relPath)
+      mkdirSync(dirname(destPath), { recursive: true })
+      writeFileSync(destPath, substituteMockRepos(content))
     }
 
     // Create initial commit
@@ -587,6 +594,25 @@ export class RenovateTestContext {
     }
 
     return packageFile
+  }
+
+  // Returns `undefined` when the manager produced no package files or the
+  // file was not picked up, instead of throwing. Use this when a test
+  // expects "no match" rather than a hit.
+  tryGetPackageFile(
+    manager: string,
+    filePath: string,
+  ): PackageFile | undefined {
+    if (!this.report) {
+      throw new Error('Report not available. Did you call setup()?')
+    }
+    const repoReport = this.report.repositories['local']
+    if (!repoReport) {
+      return undefined
+    }
+    return repoReport.packageFiles[manager]?.find(
+      (f) => f.packageFile === filePath,
+    )
   }
 
   /**

--- a/tests/mise-action-custom-manager.test.ts
+++ b/tests/mise-action-custom-manager.test.ts
@@ -2,8 +2,6 @@ import { expect, it } from 'vitest'
 
 import { describeWithRenovate } from './helpers/with-renovate'
 
-const WORKFLOW_PATH = '.github/workflows/test.yml'
-
 function workflow(stepsBody: string): string {
   return `name: Test
 on: push
@@ -98,7 +96,7 @@ const cases: Case[] = [
     expected: [MISE_DEP('2026.6.6'), MISE_DEP('2026.6.7')],
   },
   {
-    name: 'unrelated action with a version: key (must not match)',
+    name: 'unrelated action with a version: key',
     yaml: workflow(`      - uses: actions/setup-node@v4
         with:
           version: 20.0.0
@@ -106,7 +104,7 @@ const cases: Case[] = [
     expected: [],
   },
   {
-    name: 'version: outside the with: block (must not match)',
+    name: 'version: outside the with: block',
     yaml: workflow(`      - uses: jdx/mise-action@v2
         env:
           version: 9.9.9
@@ -118,7 +116,7 @@ const cases: Case[] = [
   {
     // Pins the bleed-prevention guard: the continuation pattern must not
     // span the boundary into a sibling step's `with: version:`.
-    name: 'jdx/mise-action without version: followed by another step that has version: (must not match)',
+    name: 'jdx/mise-action without version: followed by another step that has version:',
     yaml: workflow(`      - uses: jdx/mise-action@v2
         with:
           experimental: true
@@ -128,25 +126,39 @@ const cases: Case[] = [
 `),
     expected: [],
   },
+  {
+    // Anchors the match to a `uses:` line so a stray `jdx/mise-action@…`
+    // mention in a `run:` script or comment does not trigger extraction.
+    name: 'jdx/mise-action@ string inside a run: command, followed by an unrelated step with version:',
+    yaml: workflow(`      - name: Note
+        run: echo "migrating from jdx/mise-action@v1"
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+`),
+    expected: [],
+  },
 ]
 
-for (const { name, yaml, expected } of cases) {
-  describeWithRenovate(
-    `mise-action customManager: ${name}`,
-    {
-      fixtures: [],
-      inlineFiles: { [WORKFLOW_PATH]: yaml },
-    },
-    (ctx) => {
-      it('produces the expected dep set', () => {
-        const deps = ctx.tryGetPackageFile('regex', WORKFLOW_PATH)?.deps ?? []
-        const normalized: ExpectedDep[] = deps.map((d) => ({
-          currentValue: d.currentValue ?? '',
-          depName: d.depName ?? '',
-          datasource: d.datasource ?? '',
-        }))
-        expect(normalized).toEqual(expected)
-      })
-    },
-  )
-}
+const filesByCase = cases.map((c, i) => ({
+  ...c,
+  path: `.github/workflows/case-${String(i).padStart(2, '0')}.yml`,
+}))
+
+const inlineFiles = Object.fromEntries(filesByCase.map((c) => [c.path, c.yaml]))
+
+describeWithRenovate(
+  'mise-action customManager',
+  { fixtures: [], inlineFiles },
+  (ctx) => {
+    it.each(filesByCase)('$name', ({ path, expected }) => {
+      const deps = ctx.tryGetPackageFile('regex', path)?.deps ?? []
+      const normalized: ExpectedDep[] = deps.map((d) => ({
+        currentValue: d.currentValue ?? '',
+        depName: d.depName ?? '',
+        datasource: d.datasource ?? '',
+      }))
+      expect(normalized).toEqual(expected)
+    })
+  },
+)

--- a/tests/mise-action-custom-manager.test.ts
+++ b/tests/mise-action-custom-manager.test.ts
@@ -1,0 +1,152 @@
+import { expect, it } from 'vitest'
+
+import { describeWithRenovate } from './helpers/with-renovate'
+
+const WORKFLOW_PATH = '.github/workflows/test.yml'
+
+function workflow(stepsBody: string): string {
+  return `name: Test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+${stepsBody}`
+}
+
+interface ExpectedDep {
+  currentValue: string
+  depName: string
+  datasource: string
+}
+
+interface Case {
+  name: string
+  yaml: string
+  expected: ExpectedDep[]
+}
+
+const MISE_DEP = (currentValue: string): ExpectedDep => ({
+  currentValue,
+  depName: 'jdx/mise',
+  datasource: 'github-releases',
+})
+
+const cases: Case[] = [
+  {
+    name: 'minimal with: version: block',
+    yaml: workflow(`      - uses: jdx/mise-action@v2
+        with:
+          version: 2026.6.6
+`),
+    expected: [MISE_DEP('2026.6.6')],
+  },
+  {
+    name: 'other keys before version:',
+    yaml: workflow(`      - uses: jdx/mise-action@v2
+        with:
+          experimental: true
+          install: true
+          version: 2026.6.6
+`),
+    expected: [MISE_DEP('2026.6.6')],
+  },
+  {
+    name: 'other keys after version:',
+    yaml: workflow(`      - uses: jdx/mise-action@v2
+        with:
+          version: 2026.6.6
+          install: true
+          cache: true
+`),
+    expected: [MISE_DEP('2026.6.6')],
+  },
+  {
+    name: 'comment line inside with: block',
+    yaml: workflow(`      - uses: jdx/mise-action@v2
+        with:
+          # pin mise to avoid latest-asset-missing breakage
+          version: 2026.6.6
+`),
+    expected: [MISE_DEP('2026.6.6')],
+  },
+  {
+    name: 'trailing comment on uses:',
+    yaml: workflow(`      - uses: jdx/mise-action@v2 # comment
+        with:
+          version: 2026.6.6
+`),
+    expected: [MISE_DEP('2026.6.6')],
+  },
+  {
+    name: 'pinned SHA reference for the action',
+    yaml: workflow(`      - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v3.5.1
+        with:
+          version: 2026.6.6
+`),
+    expected: [MISE_DEP('2026.6.6')],
+  },
+  {
+    name: 'multiple jdx/mise-action steps',
+    yaml: workflow(`      - uses: jdx/mise-action@v2
+        with:
+          version: 2026.6.6
+      - uses: jdx/mise-action@v2
+        with:
+          version: 2026.6.7
+`),
+    expected: [MISE_DEP('2026.6.6'), MISE_DEP('2026.6.7')],
+  },
+  {
+    name: 'unrelated action with a version: key (must not match)',
+    yaml: workflow(`      - uses: actions/setup-node@v4
+        with:
+          version: 20.0.0
+`),
+    expected: [],
+  },
+  {
+    name: 'version: outside the with: block (must not match)',
+    yaml: workflow(`      - uses: jdx/mise-action@v2
+        env:
+          version: 9.9.9
+        with:
+          install: true
+`),
+    expected: [],
+  },
+  {
+    // Pins the bleed-prevention guard: the continuation pattern must not
+    // span the boundary into a sibling step's `with: version:`.
+    name: 'jdx/mise-action without version: followed by another step that has version: (must not match)',
+    yaml: workflow(`      - uses: jdx/mise-action@v2
+        with:
+          experimental: true
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+`),
+    expected: [],
+  },
+]
+
+for (const { name, yaml, expected } of cases) {
+  describeWithRenovate(
+    `mise-action customManager: ${name}`,
+    {
+      fixtures: [],
+      inlineFiles: { [WORKFLOW_PATH]: yaml },
+    },
+    (ctx) => {
+      it('produces the expected dep set', () => {
+        const deps = ctx.tryGetPackageFile('regex', WORKFLOW_PATH)?.deps ?? []
+        const normalized: ExpectedDep[] = deps.map((d) => ({
+          currentValue: d.currentValue ?? '',
+          depName: d.depName ?? '',
+          datasource: d.datasource ?? '',
+        }))
+        expect(normalized).toEqual(expected)
+      })
+    },
+  )
+}


### PR DESCRIPTION
## Purpose

- Keep the pinned mise version up to date across every CI workflow automatically

## Approach

- Add a customManager in `base.json5` so every repository extending it picks up `jdx/mise-action`'s `with: version:` as a `jdx/mise` GitHub Release without any per-repo configuration

<details>
<summary>Design decisions</summary>

#### Where to declare the manager

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Chosen   | A customManager in `base.json5` | Active in every repo that extends it, with no per-repo annotation | `base.json5` grows over time |
| Rejected | A `# renovate:` magic comment in each workflow | Scope can be opted in per call site | Requires an annotation at every call site |

</details>
