### PR TITLE
ci: pin mise version to 2026.6.6 in mise-action

### DIFF
--- a/.github/workflows/sync-generic-boilerplate.yml
+++ b/.github/workflows/sync-generic-boilerplate.yml
@@ -27,6 +27,8 @@ jobs:
           persist-credentials: false
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.6.6
 
       - run: corepack enable
 


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/generic-boilerplate/pull/428
- Align the mise version across the org by applying mise 2026.6.6 (already set in generic-boilerplate v0.8.4) to this repo's own workflow

## Approach

- Pin the mise version used by the `jdx/mise-action` call in [`sync-generic-boilerplate.yml`](https://github.com/fohte/renovate-config/blob/82d45f3/.github/workflows/sync-generic-boilerplate.yml)
