### PR TITLE
base: enable auto-update of env vars via magic comments in GitHub Actions

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -15,6 +15,11 @@
     // that only matches `vX.Y.Z` tags, filtering out floating tags like `v3`.
     // See https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver
     'helpers:pinGitHubActionDigestsToSemver',
+    // Pick up `# renovate: datasource=... depName=...` magic comments on env
+    // variables in GitHub Actions workflows so pinned tool versions
+    // (e.g. `MERGIRAF_VERSION: v0.17.0`) are updated automatically.
+    // See https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions
+    'customManagers:githubActionsVersions',
   ],
 
   configMigration: true,

--- a/base.json5
+++ b/base.json5
@@ -15,10 +15,6 @@
     // that only matches `vX.Y.Z` tags, filtering out floating tags like `v3`.
     // See https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver
     'helpers:pinGitHubActionDigestsToSemver',
-    // Pick up `# renovate: datasource=... depName=...` magic comments on env
-    // variables in GitHub Actions workflows so pinned tool versions
-    // (e.g. `MERGIRAF_VERSION: v0.17.0`) are updated automatically.
-    // See https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions
     'customManagers:githubActionsVersions',
   ],
 


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/generic-boilerplate/pull/453
- Allow downstream repos to pin tool versions in GitHub Actions workflow env vars with `# renovate: datasource=... depName=...` magic comments and have Renovate update them automatically

## Approach

- Add Renovate's built-in [`customManagers:githubActionsVersions`](https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions) preset to `extends`
