### PR TITLE
base: extend group:monorepos preset

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -16,9 +16,7 @@
     // See https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver
     'helpers:pinGitHubActionDigestsToSemver',
     'customManagers:githubActionsVersions',
-    // Aggregates known monorepo packages across ecosystems (npm, Go, Rust, etc.)
-    // into a single PR per monorepo.
-    // See https://docs.renovatebot.com/presets-group/#groupmonorepos
+    // https://docs.renovatebot.com/presets-group/#groupmonorepos
     'group:monorepos',
   ],
 

--- a/base.json5
+++ b/base.json5
@@ -16,6 +16,10 @@
     // See https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver
     'helpers:pinGitHubActionDigestsToSemver',
     'customManagers:githubActionsVersions',
+    // Aggregates known monorepo packages across ecosystems (npm, Go, Rust, etc.)
+    // into a single PR per monorepo.
+    // See https://docs.renovatebot.com/presets-group/#groupmonorepos
+    'group:monorepos',
   ],
 
   configMigration: true,

--- a/tests/__fixtures__/group-monorepos/package.json
+++ b/tests/__fixtures__/group-monorepos/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-monorepos",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@storybook/test": "8.0.0",
+    "@storybook/blocks": "8.0.0"
+  }
+}

--- a/tests/group-monorepos.test.ts
+++ b/tests/group-monorepos.test.ts
@@ -1,0 +1,51 @@
+import { expect, it } from 'vitest'
+
+import { describeWithRenovate } from './helpers/with-renovate'
+
+// Verify `group:monorepos` aggregates npm patches of known monorepo packages
+// into the ecosystem-named group (`storybook monorepo`) instead of the
+// `devDependencies (non-major)` fallback declared in `node.json5`. This
+// guards against future packageRule order changes silently re-burying the
+// monorepo grouping under the fallback.
+
+describeWithRenovate(
+  'group:monorepos overrides node.json5 devDependencies (non-major) fallback',
+  {
+    fixtures: ['group-monorepos/package.json'],
+    mockNpmPackages: [
+      {
+        name: '@storybook/test',
+        versions: ['8.0.0', '8.0.1'],
+        sourceUrl: 'https://github.com/storybookjs/storybook',
+      },
+      {
+        name: '@storybook/blocks',
+        versions: ['8.0.0', '8.0.1'],
+        sourceUrl: 'https://github.com/storybookjs/storybook',
+      },
+    ],
+    additionalConfigs: ['node.json5'],
+    allowedExtends: ['group:monorepos'],
+  },
+  (ctx) => {
+    it('groups storybook patches into the storybook monorepo PR', () => {
+      const storybookBranch = ctx
+        .getBranches()
+        .find((b) => b.branchName?.includes('storybook-monorepo') === true)
+
+      expect(storybookBranch).toMatchObject({
+        prTitle: expect.stringContaining('storybook monorepo') as unknown,
+        upgrades: expect.arrayContaining([
+          expect.objectContaining({
+            depName: '@storybook/test',
+            updateType: 'patch',
+          }),
+          expect.objectContaining({
+            depName: '@storybook/blocks',
+            updateType: 'patch',
+          }),
+        ]) as unknown,
+      })
+    })
+  },
+)

--- a/tests/helpers/renovate-test-context.ts
+++ b/tests/helpers/renovate-test-context.ts
@@ -54,6 +54,9 @@ export interface MockNpmPackage {
   // Map of version to release timestamp (ISO 8601 format)
   // If not specified, defaults to a date old enough to pass minimumReleaseAge
   releaseTimes?: Record<string, string>
+  // Source repository URL injected into each version's `repository.url`.
+  // Required for `matchSourceUrls`-based presets (e.g. `monorepo:storybook`).
+  sourceUrl?: string
 }
 
 export interface MockGitHubRepo {
@@ -317,6 +320,9 @@ export class RenovateTestContext {
             version,
             dependencies: {},
             devDependencies: {},
+            ...(pkgData.sourceUrl !== undefined
+              ? { repository: { type: 'git', url: pkgData.sourceUrl } }
+              : {}),
           }
           time[version] = pkgData.releaseTimes?.[version] ?? defaultReleaseTime
         }


### PR DESCRIPTION
## Purpose

- Updates to monorepo packages (Storybook, ESLint, Vitest, TanStack, etc.) get absorbed into the generic `devDependencies (non-major)` group, so the PR title hides what is actually being updated
    - Example: [`deps: Update devDependencies (non-major) to v10.4.6`](https://github.com/fohte/generic-boilerplate/pull/449) (the PR actually bumps five Storybook packages released together)

## Approach

- Extend the built-in [`group:monorepos`](https://docs.renovatebot.com/presets-group/#groupmonorepos) preset in `base.json5` so ecosystem-named groups (e.g. `storybook monorepo`) take precedence over the downstream `devDependencies (non-major)` rule
