### PR TITLE
base: scope mise automerge to jdx/mise only

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -233,11 +233,11 @@
       commitMessagePrefix: 'chore:',
       semanticCommitScope: null,
     },
-    // mise releases use CalVer (`YYYY.M.PATCH`), so Renovate's
+    // jdx/mise itself releases under CalVer (`YYYY.M.PATCH`), so Renovate's
     // patch/minor/major classification does not reflect risk.
     // See https://mise.jdx.dev/faq.html
     {
-      matchManagers: ['mise'],
+      matchPackageNames: ['jdx/mise'],
       automerge: true,
     },
   ],


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/renovate-config/pull/391
- Intended to automerge mise itself, but the rule actually automerged every tool managed by mise

## Approach

- Automerge jdx/mise only
