### PR TITLE
base: stop Renovate's copier manager from updating generic-boilerplate

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -189,10 +189,7 @@
     // (invoked from `boilerplate-update.yml`) instead of Renovate's copier manager.
     {
       matchManagers: ['copier'],
-      matchPackageNames: [
-        'https://github.com/fohte/generic-boilerplate',
-        'https://github.com/fohte/generic-boilerplate.git',
-      ],
+      matchPackageNames: ['/fohte\\/generic-boilerplate(?:\\.git)?$/'],
       enabled: false,
     },
 

--- a/base.json5
+++ b/base.json5
@@ -157,7 +157,6 @@
     //   | dependencies    | deps:        | deps:        | deps:        | chore(deps): |
     //   | devDependencies | chore:       | chore:       | chore:       | chore:       |
     //   | github-actions  | ci:          | ci:          | ci:          | ci:          |
-    //   | copier          | chore(deps): | chore(deps): | chore(deps): | chore(deps): |
     //   | mise            | chore:       | chore:       | chore:       | chore:       |
     //   | jdx/mise        | ci:          | ci:          | ci:          | ci:          |
     {
@@ -181,11 +180,20 @@
       commitMessagePrefix: 'ci:',
       semanticCommitScope: null,
     },
-    // Copier templates are boilerplate references, not runtime/dev dependencies.
+
+    // ==========================================================================
+    // copier
+    // ==========================================================================
+    // Disable Renovate-managed updates for `fohte/generic-boilerplate`.
+    // Consumer repositories update this template via `fohte/copier-update-action`
+    // (invoked from `boilerplate-update.yml`) instead of Renovate's copier manager.
     {
       matchManagers: ['copier'],
-      commitMessagePrefix: 'chore(deps):',
-      semanticCommitScope: null,
+      matchPackageNames: [
+        'https://github.com/fohte/generic-boilerplate',
+        'https://github.com/fohte/generic-boilerplate.git',
+      ],
+      enabled: false,
     },
 
     // ==========================================================================
@@ -201,18 +209,6 @@
       matchManagers: ['pre-commit'],
       matchUpdateTypes: ['minor', 'patch'],
       automerge: true,
-    },
-
-    // ==========================================================================
-    // copier
-    // ==========================================================================
-    // For copier templates with GitHub URL package names,
-    // use only the repository name in commit messages instead of the full URL.
-    // Handles both https://github.com/owner/repo and https://github.com/owner/repo.git
-    {
-      matchManagers: ['copier'],
-      matchPackageNames: ['/^https:\\/\\/github\\.com\\//'],
-      commitMessageTopic: '{{{replace "\\.git$" "" (replace "https://github\\.com/[^/]+/" "" packageName)}}}',
     },
 
     // ==========================================================================

--- a/tests/__fixtures__/.copier-answers.yml
+++ b/tests/__fixtures__/.copier-answers.yml
@@ -1,3 +1,0 @@
-# Changes here will be overwritten by Copier
-_commit: v1.0.0
-_src_path: '{{MOCK_REPO:test-template}}'

--- a/tests/pr-title.test.ts
+++ b/tests/pr-title.test.ts
@@ -11,7 +11,6 @@ import {
 //   | dependencies    | deps:        | deps:        | deps:        | chore(deps): |
 //   | devDependencies | chore:       | chore:       | chore:       | chore:       |
 //   | github-actions  | ci:          | ci:          | ci:          | ci:          |
-//   | copier          | chore(deps): | chore(deps): | chore(deps): | chore(deps): |
 //   | mise            | chore:       | chore:       | chore:       | chore:       |
 //   | packageManager  | chore:       | chore:       | chore:       | chore:       |
 
@@ -99,18 +98,6 @@ const testCases: TestCase[] = [
     },
     depName: 'pnpm',
     expectedPrefix: /^chore: /,
-    updateType: 'minor',
-  },
-  // copier
-  {
-    category: 'copier',
-    description: 'minor update',
-    options: {
-      fixtures: ['.copier-answers.yml'],
-      mockRepos: [{ name: 'test-template', tags: ['v1.0.0', 'v1.1.0'] }],
-    },
-    depName: 'test-template',
-    expectedPrefix: /^chore\(deps\): /,
     updateType: 'minor',
   },
   // github-actions


### PR DESCRIPTION
## Purpose

- Stop `fohte/generic-boilerplate` update PRs from being opened twice — once by Renovate's built-in copier manager and once by the consumer-side [`boilerplate-update.yml`](https://github.com/fohte/generic-boilerplate/blob/main/template/.github/workflows/boilerplate-update.yml.jinja) workflow.

## Approach

- Add an `enabled: false` rule scoped via `matchPackageNames` to `https://github.com/fohte/generic-boilerplate` (with and without the `.git` suffix).
- Drop the existing copier `commitMessagePrefix` / `commitMessageTopic` rules and the accompanying test — they only ever shaped generic-boilerplate PRs.
