### PR TITLE
node: group langchain packages into a single PR

### DIFF
--- a/node.json5
+++ b/node.json5
@@ -69,6 +69,16 @@
       matchUpdateTypes: ['major', 'minor'],
       groupName: 'node',
     },
+    // Group langchainjs monorepo packages together, since they have peer
+    // dependency constraints on each other (e.g. @langchain/openai requires
+    // a matching @langchain/core range) that Renovate cannot detect on its
+    // own; this monorepo isn't registered in Renovate's group:monorepos
+    // preset (only the unrelated Java langchain4j is).
+    {
+      matchManagers: ['npm', 'bun'],
+      matchPackageNames: ['@langchain/**'],
+      groupName: 'langchain monorepo',
+    },
 
     // ==========================================================================
     // release-please integration

--- a/node.json5
+++ b/node.json5
@@ -76,7 +76,7 @@
     // preset (only the unrelated Java langchain4j is).
     {
       matchManagers: ['npm', 'bun'],
-      matchPackageNames: ['@langchain/**'],
+      matchPackageNames: ['@langchain/**', 'langchain'],
       groupName: 'langchain monorepo',
     },
 

--- a/tests/__fixtures__/langchain-monorepo/package.json
+++ b/tests/__fixtures__/langchain-monorepo/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@langchain/core": "1.2.1",
-    "@langchain/openai": "1.5.4"
+    "@langchain/openai": "1.5.4",
+    "langchain": "1.5.2"
   }
 }

--- a/tests/__fixtures__/langchain-monorepo/package.json
+++ b/tests/__fixtures__/langchain-monorepo/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-langchain-monorepo",
+  "version": "1.0.0",
+  "dependencies": {
+    "@langchain/core": "1.2.1",
+    "@langchain/openai": "1.5.4"
+  }
+}

--- a/tests/langchain-monorepo.test.ts
+++ b/tests/langchain-monorepo.test.ts
@@ -2,11 +2,10 @@ import { expect, it } from 'vitest'
 
 import { describeWithRenovate } from './helpers/with-renovate'
 
-// @langchain/* packages come from the langchainjs monorepo and are not
-// registered in Renovate's built-in group:monorepos preset, so without a
-// custom groupName they would be updated in separate PRs and could break
-// peer dependency constraints between them (e.g. @langchain/openai requires
-// a matching @langchain/core range).
+// Verify the langchain monorepo packageRule groups scoped (@langchain/*) and
+// unscoped (langchain) packages into a single PR. This guards against the
+// peer dependency breakage that happens when @langchain/core and a dependent
+// package (e.g. @langchain/openai or langchain) update in separate PRs.
 
 describeWithRenovate(
   'langchain monorepo grouping',
@@ -16,18 +15,20 @@ describeWithRenovate(
       {
         name: '@langchain/core',
         versions: ['1.2.1', '1.2.2'],
-        sourceUrl: 'https://github.com/langchain-ai/langchainjs',
       },
       {
         name: '@langchain/openai',
         versions: ['1.5.4', '1.5.5'],
-        sourceUrl: 'https://github.com/langchain-ai/langchainjs',
+      },
+      {
+        name: 'langchain',
+        versions: ['1.5.2', '1.5.3'],
       },
     ],
     additionalConfigs: ['node.json5'],
   },
   (ctx) => {
-    it('groups @langchain/core and @langchain/openai into the same PR', () => {
+    it('groups @langchain/core, @langchain/openai, and langchain into the same PR', () => {
       const langchainBranch = ctx
         .getBranches()
         .find((b) => b.branchName?.includes('langchain-monorepo') === true)
@@ -37,6 +38,7 @@ describeWithRenovate(
         upgrades: expect.arrayContaining([
           expect.objectContaining({ depName: '@langchain/core' }),
           expect.objectContaining({ depName: '@langchain/openai' }),
+          expect.objectContaining({ depName: 'langchain' }),
         ]) as unknown,
       })
     })

--- a/tests/langchain-monorepo.test.ts
+++ b/tests/langchain-monorepo.test.ts
@@ -1,0 +1,44 @@
+import { expect, it } from 'vitest'
+
+import { describeWithRenovate } from './helpers/with-renovate'
+
+// @langchain/* packages come from the langchainjs monorepo and are not
+// registered in Renovate's built-in group:monorepos preset, so without a
+// custom groupName they would be updated in separate PRs and could break
+// peer dependency constraints between them (e.g. @langchain/openai requires
+// a matching @langchain/core range).
+
+describeWithRenovate(
+  'langchain monorepo grouping',
+  {
+    fixtures: ['langchain-monorepo/package.json'],
+    mockNpmPackages: [
+      {
+        name: '@langchain/core',
+        versions: ['1.2.1', '1.2.2'],
+        sourceUrl: 'https://github.com/langchain-ai/langchainjs',
+      },
+      {
+        name: '@langchain/openai',
+        versions: ['1.5.4', '1.5.5'],
+        sourceUrl: 'https://github.com/langchain-ai/langchainjs',
+      },
+    ],
+    additionalConfigs: ['node.json5'],
+  },
+  (ctx) => {
+    it('groups @langchain/core and @langchain/openai into the same PR', () => {
+      const langchainBranch = ctx
+        .getBranches()
+        .find((b) => b.branchName?.includes('langchain-monorepo') === true)
+
+      expect(langchainBranch).toMatchObject({
+        prTitle: expect.stringContaining('langchain monorepo') as unknown,
+        upgrades: expect.arrayContaining([
+          expect.objectContaining({ depName: '@langchain/core' }),
+          expect.objectContaining({ depName: '@langchain/openai' }),
+        ]) as unknown,
+      })
+    })
+  },
+)


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/slack-bot/pull/110
- Updating `@langchain/core` and `@langchain/openai` from the langchainjs monorepo in separate PRs breaks their peer dependency constraint and fails CI

## Approach

- Group `@langchain/**` and `langchain` under a single `packageRule` so they land in the same PR
