### PR TITLE
base: automerge a subset of mise-managed packages

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -242,5 +242,31 @@
       semanticCommitScope: null,
       automerge: true,
     },
+    // Automerge minor/patch for mise-managed formatter/linter/git-hook CLIs:
+    // narrowly-scoped, deterministic tools whose only effect is on the
+    // repository's own lint/format/commit-hook workflow, so a regression
+    // surfaces immediately as a CI or lefthook failure rather than silently
+    // changing runtime or infrastructure behavior. Same rationale as the
+    // `pre-commit` automerge rule above. Excludes tools with broad blast
+    // radius (language runtimes, package managers, infra/cluster CLIs) and
+    // security scanners (e.g. betterleaks) whose regressions can fail silently.
+    //
+    // Matched by upstream packageName (not the mise.toml key) so both short
+    // registry names (e.g. `lefthook`) and explicit backend-prefixed names
+    // (e.g. `aqua:evilmartians/lefthook`) resolve to the same rule.
+    {
+      matchManagers: ['mise'],
+      matchPackageNames: [
+        'evilmartians/lefthook', // lefthook
+        'rhysd/actionlint', // actionlint
+        'suzuki-shunsuke/pinact', // pinact
+        'koalaman/shellcheck', // shellcheck
+        'mvdan/sh', // shfmt
+        'prettier', // npm:prettier
+        '@commitlint/cli', // npm:@commitlint/cli
+      ],
+      matchUpdateTypes: ['minor', 'patch'],
+      automerge: true,
+    },
   ],
 }

--- a/base.json5
+++ b/base.json5
@@ -242,14 +242,10 @@
       semanticCommitScope: null,
       automerge: true,
     },
-    // Automerge minor/patch for mise-managed formatter/linter/git-hook CLIs:
-    // narrowly-scoped, deterministic tools whose only effect is on the
-    // repository's own lint/format/commit-hook workflow, so a regression
-    // surfaces immediately as a CI or lefthook failure rather than silently
-    // changing runtime or infrastructure behavior. Same rationale as the
-    // `pre-commit` automerge rule above. Excludes tools with broad blast
-    // radius (language runtimes, package managers, infra/cluster CLIs) and
-    // security scanners (e.g. betterleaks) whose regressions can fail silently.
+    // Automerge minor/patch for mise-managed formatter/linter/git-hook CLIs.
+    // Excludes tools with broad blast radius (language runtimes, package
+    // managers, infra/cluster CLIs) and security scanners (e.g. betterleaks)
+    // whose regressions can fail silently.
     //
     // Matched by upstream packageName (not the mise.toml key) so both short
     // registry names (e.g. `lefthook`) and explicit backend-prefixed names
@@ -262,8 +258,12 @@
         'suzuki-shunsuke/pinact', // pinact
         'koalaman/shellcheck', // shellcheck
         'mvdan/sh', // shfmt
-        'prettier', // npm:prettier
         '@commitlint/cli', // npm:@commitlint/cli
+        'prettier', // npm:prettier
+        // mise's registry resolves the bare `prettier` short name (no
+        // `npm:` prefix) to the prettier/prettier GitHub repo via
+        // github-releases, not the npm package.
+        'prettier/prettier', // prettier
       ],
       matchUpdateTypes: ['minor', 'patch'],
       automerge: true,

--- a/tests/__fixtures__/mise-automerge-safe-tools/.mise.toml
+++ b/tests/__fixtures__/mise-automerge-safe-tools/.mise.toml
@@ -1,5 +1,6 @@
 [tools]
 "npm:prettier" = "3.0.0"
+prettier = "3.0.0"
 "npm:@commitlint/cli" = "21.0.0"
 shfmt = "3.12.0"
 "aqua:mvdan/sh" = "3.12.0"

--- a/tests/__fixtures__/mise-automerge-safe-tools/.mise.toml
+++ b/tests/__fixtures__/mise-automerge-safe-tools/.mise.toml
@@ -1,0 +1,6 @@
+[tools]
+"npm:prettier" = "3.0.0"
+"npm:@commitlint/cli" = "21.0.0"
+shfmt = "3.12.0"
+"aqua:mvdan/sh" = "3.12.0"
+"aqua:jqlang/jq" = "1.8.0"

--- a/tests/helpers/renovate-test-context.ts
+++ b/tests/helpers/renovate-test-context.ts
@@ -31,6 +31,12 @@ const GIT_ENV = {
   GIT_CONFIG_SYSTEM: '/dev/null',
 }
 
+// Default release time for mock packages, old enough to satisfy
+// `minimumReleaseAge: '7 days'` in base.json5 without per-test overrides.
+function defaultMockReleaseTime(): string {
+  return new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+}
+
 function initGitRepo(dir: string): void {
   const opts = { cwd: dir, stdio: 'pipe' as const, env: GIT_ENV }
   execSync('git init', opts)
@@ -310,9 +316,7 @@ export class RenovateTestContext {
         const time: Record<string, string> = {}
 
         // Default to 30 days ago if no release time specified
-        const defaultReleaseTime = new Date(
-          Date.now() - 30 * 24 * 60 * 60 * 1000,
-        ).toISOString()
+        const defaultReleaseTime = defaultMockReleaseTime()
 
         for (const version of pkgData.versions) {
           versions[version] = {
@@ -408,12 +412,7 @@ export class RenovateTestContext {
                 return
               }
 
-              // Default to 30 days old so mocked releases satisfy the
-              // `minimumReleaseAge: '7 days'` default in base.json5, matching
-              // the mock npm server's default release time.
-              const releaseTimestamp = new Date(
-                Date.now() - 30 * 24 * 60 * 60 * 1000,
-              ).toISOString()
+              const releaseTimestamp = defaultMockReleaseTime()
 
               // github-releases datasource (queryReleases) sends a `releases(...)`
               // query, distinct from the `refs(...)` query used by the

--- a/tests/helpers/renovate-test-context.ts
+++ b/tests/helpers/renovate-test-context.ts
@@ -385,6 +385,7 @@ export class RenovateTestContext {
           req.on('end', () => {
             try {
               interface GraphQLQuery {
+                query?: string
                 variables?: { owner?: string; name?: string }
               }
               // Use JSON5.parse with type parameter to avoid unsafe any assignment
@@ -407,15 +408,40 @@ export class RenovateTestContext {
                 return
               }
 
-              // Build GraphQL response for refs query
-              const nodes = repoData.tags.map((tag) => ({
-                version: tag,
-                target: {
-                  type: 'Commit',
-                  oid: '0'.repeat(40),
-                  releaseTimestamp: new Date().toISOString(),
-                },
-              }))
+              // Default to 30 days old so mocked releases satisfy the
+              // `minimumReleaseAge: '7 days'` default in base.json5, matching
+              // the mock npm server's default release time.
+              const releaseTimestamp = new Date(
+                Date.now() - 30 * 24 * 60 * 60 * 1000,
+              ).toISOString()
+
+              // github-releases datasource (queryReleases) sends a `releases(...)`
+              // query, distinct from the `refs(...)` query used by the
+              // github-tags datasource (queryTags). Detect which one was sent
+              // and shape the response nodes to match, since the two use
+              // different field sets.
+              const isReleasesQuery =
+                query.query?.includes('releases(') ?? false
+
+              const nodes = isReleasesQuery
+                ? repoData.tags.map((tag, index) => ({
+                    version: tag,
+                    releaseTimestamp,
+                    isDraft: false,
+                    isPrerelease: false,
+                    url: `https://github.com/${repoName}/releases/tag/${tag}`,
+                    id: index,
+                    name: tag,
+                    description: null,
+                  }))
+                : repoData.tags.map((tag) => ({
+                    version: tag,
+                    target: {
+                      type: 'Commit',
+                      oid: '0'.repeat(40),
+                      releaseTimestamp,
+                    },
+                  }))
 
               res.writeHead(200, { 'Content-Type': 'application/json' })
               res.end(
@@ -704,10 +730,10 @@ export class RenovateTestContext {
       })
     }
 
-    // Add packageRule for github-tags datasource
+    // Add packageRule for github-tags/github-releases datasources
     if (this.mockGitHubPort !== null) {
       packageRules.unshift({
-        matchDatasources: ['github-tags'],
+        matchDatasources: ['github-tags', 'github-releases'],
         registryUrls: [`http://127.0.0.1:${String(this.mockGitHubPort)}/`],
       })
     }

--- a/tests/mise-automerge-safe-tools.test.ts
+++ b/tests/mise-automerge-safe-tools.test.ts
@@ -1,0 +1,89 @@
+import { expect, it } from 'vitest'
+
+import { describeWithRenovate } from './helpers/with-renovate'
+
+describeWithRenovate(
+  'mise automerge for formatter/linter/git-hook tools',
+  {
+    fixtures: ['mise-automerge-safe-tools/.mise.toml'],
+    mockNpmPackages: [
+      { name: 'prettier', versions: ['3.0.0', '3.1.0', '4.0.0'] },
+      { name: '@commitlint/cli', versions: ['21.0.0', '21.0.1'] },
+    ],
+    mockGitHubRepos: [
+      { name: 'mvdan/sh', tags: ['v3.12.0', 'v3.12.1'] },
+      { name: 'jqlang/jq', tags: ['v1.8.0', 'v1.8.1'] },
+    ],
+  },
+  (ctx) => {
+    it('should automerge a minor update but not a major update for npm:prettier', () => {
+      const branches = ctx.getBranches()
+      const minorBranch = branches.find(
+        (b) =>
+          b.upgrades?.some(
+            (u) => u.depName === 'npm:prettier' && u.updateType === 'minor',
+          ) ?? false,
+      )
+      const majorBranch = branches.find(
+        (b) =>
+          b.upgrades?.some(
+            (u) => u.depName === 'npm:prettier' && u.updateType === 'major',
+          ) ?? false,
+      )
+
+      expect(minorBranch?.automerge).toBe(true)
+      expect(majorBranch?.automerge).toBeFalsy()
+    })
+
+    it('should automerge a patch update for npm:@commitlint/cli', () => {
+      const branch = ctx
+        .getBranches()
+        .find(
+          (b) =>
+            b.upgrades?.some((u) => u.depName === 'npm:@commitlint/cli') ??
+            false,
+        )
+
+      expect(branch).toMatchObject({
+        automerge: true,
+        upgrades: expect.arrayContaining([
+          expect.objectContaining({
+            depName: 'npm:@commitlint/cli',
+            updateType: 'patch',
+          }),
+        ]) as unknown,
+      })
+    })
+
+    // shfmt (short registry name) and aqua:mvdan/sh (explicit backend prefix,
+    // as written in fohte/dotfiles) both resolve to the same upstream
+    // packageName (mvdan/sh), so the automerge rule -- matched by
+    // packageName, not the mise.toml key -- must cover both spellings.
+    it('should automerge patch updates for both the short name and the aqua-prefixed name of the same tool', () => {
+      const branches = ctx.getBranches()
+      const shortNameBranch = branches.find(
+        (b) => b.upgrades?.some((u) => u.depName === 'shfmt') ?? false,
+      )
+      const aquaPrefixedBranch = branches.find(
+        (b) => b.upgrades?.some((u) => u.depName === 'aqua:mvdan/sh') ?? false,
+      )
+
+      expect(shortNameBranch?.automerge).toBe(true)
+      expect(aquaPrefixedBranch?.automerge).toBe(true)
+    })
+
+    // aqua:jqlang/jq resolves through the same aqua backend / github-tags
+    // datasource as aqua:mvdan/sh above, so this proves the rule filters by
+    // the specific allowlisted packages rather than matching every aqua tool.
+    it('should not automerge aqua:jqlang/jq since it is not in the allowlist', () => {
+      const branch = ctx
+        .getBranches()
+        .find(
+          (b) =>
+            b.upgrades?.some((u) => u.depName === 'aqua:jqlang/jq') ?? false,
+        )
+
+      expect(branch?.automerge).toBeFalsy()
+    })
+  },
+)

--- a/tests/mise-automerge-safe-tools.test.ts
+++ b/tests/mise-automerge-safe-tools.test.ts
@@ -1,6 +1,27 @@
 import { expect, it } from 'vitest'
 
+import type { RenovateTestContext } from './helpers/renovate-test-context'
 import { describeWithRenovate } from './helpers/with-renovate'
+
+// Looks up the branch for a specific (depName, updateType) pair and reports
+// whether it was found at all, alongside its automerge status. Asserting on
+// `found` too (instead of only `automerge`) keeps the check from passing
+// vacuously when the branch/upgrade never got created (e.g. a broken mock).
+function branchAutomergeStatus(
+  ctx: RenovateTestContext,
+  depName: string,
+  updateType: string,
+): { found: boolean; automerge: boolean } {
+  const branch = ctx
+    .getBranches()
+    .find(
+      (b) =>
+        b.upgrades?.some(
+          (u) => u.depName === depName && u.updateType === updateType,
+        ) ?? false,
+    )
+  return { found: branch !== undefined, automerge: branch?.automerge === true }
+}
 
 describeWithRenovate(
   'mise automerge for formatter/linter/git-hook tools',
@@ -13,45 +34,40 @@ describeWithRenovate(
     mockGitHubRepos: [
       { name: 'mvdan/sh', tags: ['v3.12.0', 'v3.12.1'] },
       { name: 'jqlang/jq', tags: ['v1.8.0', 'v1.8.1'] },
+      { name: 'prettier/prettier', tags: ['3.0.0', '3.0.1'] },
     ],
   },
   (ctx) => {
-    it('should automerge a minor update but not a major update for npm:prettier', () => {
-      const branches = ctx.getBranches()
-      const minorBranch = branches.find(
-        (b) =>
-          b.upgrades?.some(
-            (u) => u.depName === 'npm:prettier' && u.updateType === 'minor',
-          ) ?? false,
-      )
-      const majorBranch = branches.find(
-        (b) =>
-          b.upgrades?.some(
-            (u) => u.depName === 'npm:prettier' && u.updateType === 'major',
-          ) ?? false,
-      )
+    it('should automerge a minor update for npm:prettier', () => {
+      expect(branchAutomergeStatus(ctx, 'npm:prettier', 'minor')).toEqual({
+        found: true,
+        automerge: true,
+      })
+    })
 
-      expect(minorBranch?.automerge).toBe(true)
-      expect(majorBranch?.automerge).toBeFalsy()
+    it('should not automerge a major update for npm:prettier', () => {
+      expect(branchAutomergeStatus(ctx, 'npm:prettier', 'major')).toEqual({
+        found: true,
+        automerge: false,
+      })
+    })
+
+    // The bare `prettier` short name (no `npm:` prefix) resolves to the
+    // prettier/prettier GitHub repo via github-releases, a different
+    // packageName than `npm:prettier`'s `prettier` -- both must be listed.
+    it('should automerge a patch update for the bare `prettier` short name', () => {
+      expect(branchAutomergeStatus(ctx, 'prettier', 'patch')).toEqual({
+        found: true,
+        automerge: true,
+      })
     })
 
     it('should automerge a patch update for npm:@commitlint/cli', () => {
-      const branch = ctx
-        .getBranches()
-        .find(
-          (b) =>
-            b.upgrades?.some((u) => u.depName === 'npm:@commitlint/cli') ??
-            false,
-        )
-
-      expect(branch).toMatchObject({
+      expect(
+        branchAutomergeStatus(ctx, 'npm:@commitlint/cli', 'patch'),
+      ).toEqual({
+        found: true,
         automerge: true,
-        upgrades: expect.arrayContaining([
-          expect.objectContaining({
-            depName: 'npm:@commitlint/cli',
-            updateType: 'patch',
-          }),
-        ]) as unknown,
       })
     })
 
@@ -59,31 +75,28 @@ describeWithRenovate(
     // as written in fohte/dotfiles) both resolve to the same upstream
     // packageName (mvdan/sh), so the automerge rule -- matched by
     // packageName, not the mise.toml key -- must cover both spellings.
-    it('should automerge patch updates for both the short name and the aqua-prefixed name of the same tool', () => {
-      const branches = ctx.getBranches()
-      const shortNameBranch = branches.find(
-        (b) => b.upgrades?.some((u) => u.depName === 'shfmt') ?? false,
-      )
-      const aquaPrefixedBranch = branches.find(
-        (b) => b.upgrades?.some((u) => u.depName === 'aqua:mvdan/sh') ?? false,
-      )
+    it('should automerge a patch update for the short name (shfmt)', () => {
+      expect(branchAutomergeStatus(ctx, 'shfmt', 'patch')).toEqual({
+        found: true,
+        automerge: true,
+      })
+    })
 
-      expect(shortNameBranch?.automerge).toBe(true)
-      expect(aquaPrefixedBranch?.automerge).toBe(true)
+    it('should automerge a patch update for the aqua-prefixed name (aqua:mvdan/sh)', () => {
+      expect(branchAutomergeStatus(ctx, 'aqua:mvdan/sh', 'patch')).toEqual({
+        found: true,
+        automerge: true,
+      })
     })
 
     // aqua:jqlang/jq resolves through the same aqua backend / github-tags
     // datasource as aqua:mvdan/sh above, so this proves the rule filters by
     // the specific allowlisted packages rather than matching every aqua tool.
     it('should not automerge aqua:jqlang/jq since it is not in the allowlist', () => {
-      const branch = ctx
-        .getBranches()
-        .find(
-          (b) =>
-            b.upgrades?.some((u) => u.depName === 'aqua:jqlang/jq') ?? false,
-        )
-
-      expect(branch?.automerge).toBeFalsy()
+      expect(branchAutomergeStatus(ctx, 'aqua:jqlang/jq', 'patch')).toEqual({
+        found: true,
+        automerge: false,
+      })
     })
   },
 )


### PR DESCRIPTION
## Purpose

- Reduce the manual review effort for patch/minor updates to mise-managed formatter/linter/git-hook tools

## Approach

- Survey `.mise.toml` across fohte org repositories and select only the packages whose impact stays within the repository's own lint/format/commit-hook workflow for automerge

<details>
<summary>Design decisions</summary>

#### Where to draw the line for automerge scope

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Adopted  | Allowlist by packageName | Lets packages with different blast radii be selected individually | Requires maintaining the target package list over time |
| Rejected | Automerge the entire manager via `matchManagers: ['mise']` | Simpler config | Automerges language runtimes and infra CLIs indiscriminately too (tried in [PR #391](https://github.com/fohte/renovate-config/pull/391), reverted in [PR #393](https://github.com/fohte/renovate-config/pull/393)) |

</details>
