### PR TITLE
base, node: automerge actions/* and pnpm minor updates

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -121,6 +121,15 @@
       matchUpdateTypes: ['patch', 'digest'],
       automerge: true,
     },
+    // GitHub-official actions (`actions/*`) reserve breaking changes for major
+    // releases; minor releases only add features or inputs. Third-party
+    // actions don't guarantee this, so this rule is scoped to `actions/*` only.
+    {
+      matchManagers: ['github-actions'],
+      matchPackageNames: ['actions/**'],
+      matchUpdateTypes: ['minor'],
+      automerge: true,
+    },
 
     // ==========================================================================
     // labels

--- a/node.json5
+++ b/node.json5
@@ -38,6 +38,16 @@
       matchUpdateTypes: ['minor', 'patch'],
       automerge: true,
     },
+    // `packageManager` is corepack-only and never reaches the published
+    // package. pnpm reserves breaking changes for major releases, and
+    // `packageManager` updates are enforced via corepack in CI, so a
+    // minor/patch regression would surface through the CI run itself.
+    {
+      matchManagers: ['npm'],
+      matchDepTypes: ['packageManager'],
+      matchUpdateTypes: ['minor', 'patch'],
+      automerge: true,
+    },
 
     // ==========================================================================
     // grouping

--- a/node.json5
+++ b/node.json5
@@ -41,10 +41,12 @@
     // `packageManager` is corepack-only and never reaches the published
     // package. pnpm reserves breaking changes for major releases, and
     // `packageManager` updates are enforced via corepack in CI, so a
-    // minor/patch regression would surface through the CI run itself.
+    // minor/patch regression would surface through the CI run itself. Scoped
+    // to pnpm since other package managers don't share the same guarantee.
     {
       matchManagers: ['npm'],
       matchDepTypes: ['packageManager'],
+      matchPackageNames: ['pnpm'],
       matchUpdateTypes: ['minor', 'patch'],
       automerge: true,
     },

--- a/tests/__fixtures__/github-actions-official-automerge/.github/workflows/test.yml
+++ b/tests/__fixtures__/github-actions-official-automerge/.github/workflows/test.yml
@@ -1,0 +1,8 @@
+name: Test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - uses: docker/build-push-action@v1.0.0

--- a/tests/__fixtures__/npm-package-manager-yarn/package.json
+++ b/tests/__fixtures__/npm-package-manager-yarn/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "test-package-manager-yarn",
+  "version": "1.0.0",
+  "packageManager": "yarn@1.0.0"
+}

--- a/tests/actions-minor-automerge.test.ts
+++ b/tests/actions-minor-automerge.test.ts
@@ -1,0 +1,50 @@
+import { expect, it } from 'vitest'
+
+import type { RenovateTestContext } from './helpers/renovate-test-context'
+import { describeWithRenovate } from './helpers/with-renovate'
+
+function branchAutomergeStatus(
+  ctx: RenovateTestContext,
+  depName: string,
+  updateType: string,
+): { found: boolean; automerge: boolean } {
+  const branch = ctx
+    .getBranches()
+    .find(
+      (b) =>
+        b.upgrades?.some(
+          (u) => u.depName === depName && u.updateType === updateType,
+        ) ?? false,
+    )
+  return { found: branch !== undefined, automerge: branch?.automerge === true }
+}
+
+describeWithRenovate(
+  'automerge minor updates for GitHub-official actions',
+  {
+    fixtures: ['github-actions-official-automerge/.github/workflows/test.yml'],
+    mockGitHubRepos: [
+      { name: 'actions/checkout', tags: ['v1.0.0', 'v1.1.0'] },
+      { name: 'docker/build-push-action', tags: ['v1.0.0', 'v1.1.0'] },
+    ],
+  },
+  (ctx) => {
+    it('should automerge a minor update for actions/checkout', () => {
+      expect(branchAutomergeStatus(ctx, 'actions/checkout', 'minor')).toEqual({
+        found: true,
+        automerge: true,
+      })
+    })
+
+    // Third-party actions don't share GitHub-official actions' semver
+    // discipline, so the `actions/**` rule must not match them.
+    it('should not automerge a minor update for a third-party action', () => {
+      expect(
+        branchAutomergeStatus(ctx, 'docker/build-push-action', 'minor'),
+      ).toEqual({
+        found: true,
+        automerge: false,
+      })
+    })
+  },
+)

--- a/tests/pnpm-package-manager-automerge.test.ts
+++ b/tests/pnpm-package-manager-automerge.test.ts
@@ -1,0 +1,57 @@
+import { expect, it } from 'vitest'
+
+import type { RenovateTestContext } from './helpers/renovate-test-context'
+import { describeWithRenovate } from './helpers/with-renovate'
+
+function branchAutomergeStatus(
+  ctx: RenovateTestContext,
+  depName: string,
+  updateType: string,
+): { found: boolean; automerge: boolean } {
+  const branch = ctx
+    .getBranches()
+    .find(
+      (b) =>
+        b.upgrades?.some(
+          (u) => u.depName === depName && u.updateType === updateType,
+        ) ?? false,
+    )
+  return { found: branch !== undefined, automerge: branch?.automerge === true }
+}
+
+describeWithRenovate(
+  'automerge pnpm packageManager minor/patch updates',
+  {
+    fixtures: ['pr-title-npm-package-manager/package.json'],
+    mockNpmPackages: [{ name: 'pnpm', versions: ['1.0.0', '1.1.0'] }],
+    additionalConfigs: ['node.json5'],
+  },
+  (ctx) => {
+    it('should automerge a minor update for pnpm', () => {
+      expect(branchAutomergeStatus(ctx, 'pnpm', 'minor')).toEqual({
+        found: true,
+        automerge: true,
+      })
+    })
+  },
+)
+
+describeWithRenovate(
+  'automerge scope for non-pnpm packageManager values',
+  {
+    fixtures: ['npm-package-manager-yarn/package.json'],
+    mockNpmPackages: [{ name: 'yarn', versions: ['1.0.0', '1.1.0'] }],
+    additionalConfigs: ['node.json5'],
+  },
+  (ctx) => {
+    // The rule's safety rationale (pnpm reserves breaking changes for major
+    // releases) is pnpm-specific, so it must not extend to other package
+    // managers written to the same `packageManager` field.
+    it('should not automerge a minor update for yarn', () => {
+      expect(branchAutomergeStatus(ctx, 'yarn', 'minor')).toEqual({
+        found: true,
+        automerge: false,
+      })
+    })
+  },
+)


### PR DESCRIPTION
## Purpose

- from: https://github.com/fohte/eslint-config/pull/432, https://github.com/fohte/eslint-config/pull/420
- Repos under fohte manually triage every Renovate PR for `actions/setup-node` minor updates and pnpm `packageManager` updates

## Approach

- Automerge minor updates for GitHub-official actions (`actions/*`) only
- Automerge minor/patch updates to pnpm's `packageManager` field

<details>
<summary>Design decisions</summary>

#### Scope of actions to automerge

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Adopted  | Automerge minor updates only for GitHub-official actions (`actions/*`) | Confirmed to reserve breaking changes for major releases ([past clean merges](https://github.com/fohte/eslint-config/pull/353)) | Doesn't cover third-party actions |
| Rejected | Automerge minor updates for all actions | Reduces manual triage further | Third-party actions aren't guaranteed the same semver discipline |

#### Scope of packageManager values to automerge

| Decision | Design | Pros | Cons |
| -------- | ------ | ---- | ---- |
| Adopted  | Automerge minor/patch updates only for pnpm | Confirmed to reserve breaking changes for major releases ([past clean merges](https://github.com/fohte/eslint-config/pull/379)) | Doesn't cover yarn/npm |
| Rejected | Automerge all `packageManager` values (including yarn/npm) | Simpler implementation | Unconfirmed whether other tools follow the same semver discipline, risking automerge of an unintended tool |

</details>
