### PR TITLE
copier: fix is_public not matching the actual repository visibility

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -2,7 +2,7 @@
 _commit: v0.9.0
 _src_path: https://github.com/fohte/generic-boilerplate
 description: ''
-is_public: false
+is_public: true
 is_web_app: false
 project_name: renovate-config
 repo_language: ja


### PR DESCRIPTION
## Purpose

- This repository is public on GitHub, but the `is_public` answer is still `false`, so every `copier update` regenerates the private-repo variant of the template output

## Approach

- Align the answer with reality so the [template](https://github.com/fohte/generic-boilerplate) produces its public-repo output
